### PR TITLE
use shim package rather than shim-unsigned

### DIFF
--- a/imageconfigs/demo_package_lists/uefi-bootloader-packages.json
+++ b/imageconfigs/demo_package_lists/uefi-bootloader-packages.json
@@ -3,6 +3,6 @@
         "grub2-efi-binary",
         "grub2",
         "ca-certificates",
-        "shim-unsigned"
+        "shim"
     ]
 }


### PR DESCRIPTION
Demo images should be utilizing our shim package with officially signed shim bootloaders. shim-unsigned was previously used while we were waiting for the officially signed shims to become available.